### PR TITLE
fix start cmd for WSL

### DIFF
--- a/ooba/utils/detect_hardware.py
+++ b/ooba/utils/detect_hardware.py
@@ -8,10 +8,7 @@ def detect_hardware():
     system = platform.system()
 
     if system == "Linux":
-        if "microsoft" in platform.uname().release.lower():
-            start_script_filename = "start_wsl.bat"
-        else:
-            start_script_filename = "start_linux.sh"
+        start_script_filename = "start_linux.sh"
     elif system == "Windows":
         start_script_filename = "start_windows.bat"
     elif system == "Darwin":


### PR DESCRIPTION
Fixes #2 

Assuming this was derived from the One-click installers section in the readme file in the oobabooga repo, where it states `Run the start_linux.sh, start_windows.bat, start_macos.sh, or start_wsl.bat script depending on your OS.`, the `start_wsl.bat` is actually meant to run from a Windows command prompt or PowerShell. In the context of this ooba implementation, it should just treat WSL as Linux.