### PR TITLE
Some fixes on paths on windows and finding open sockets using async

### DIFF
--- a/ooba/install.py
+++ b/ooba/install.py
@@ -138,7 +138,7 @@ def install(force_reinstall=False, verbose=False, cpu=False, gpu_choice=None, fu
     total_lines = 1738
     pbar = tqdm(total=total_lines, ncols=100)
 
-    for cmd in [base_cmd, update_cmd]:
+    for cmd in update_cmd:
         process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1)
 
         # Read the output line by line

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -5,6 +5,7 @@ import json
 import websockets
 import subprocess
 from .utils.get_open_ports import get_open_ports
+from .utils.check_port import check_port
 from .utils.detect_hardware import detect_hardware
 from .uninstall import uninstall
 import random
@@ -48,15 +49,13 @@ class llm:
             # Find an open port
             while True:
                 self.port = random.randint(2000, 10000)
-                open_ports = asyncio.run(get_open_ports(2000, 10000))
-                if self.port not in open_ports:
+                if self.port != asyncio.run(check_port(self.port, verbose=self.verbose)):
                     break
 
             # Also find an open port for blocking -- it will error otherwise
             while True:
                 unused_blocking_port = random.randint(2000, 10000)
-                open_ports = asyncio.run(get_open_ports(2000, 10000))
-                if unused_blocking_port not in open_ports:
+                if unused_blocking_port != asyncio.run(check_port(unused_blocking_port, verbose=self.verbose)):
                     break
 
             cmd = [
@@ -92,8 +91,7 @@ class llm:
             # Wait for it to be ready by checking the port
             num_attempts = 50
             for attempt in range(num_attempts):
-                open_ports = asyncio.run(get_open_ports(2000, 10000))
-                if self.port in open_ports:
+                if self.port == asyncio.run(check_port(self.port, verbose=self.verbose)):
                     if self.verbose:
                         print("Server is ready.")
                     break

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -55,6 +55,9 @@ class llm:
             # Also find an open port for blocking -- it will error otherwise
             while True:
                 unused_blocking_port = random.randint(2000, 10000)
+                #Don't use the same port, there is a small chance randint generates same int.
+                if self.port == unused_blocking_port:
+                    continue
                 if unused_blocking_port != asyncio.run(check_port(unused_blocking_port, verbose=self.verbose)):
                     break
 

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -42,20 +42,20 @@ class llm:
             install_oobabooga(gpu_choice=self.gpu_choice)
 
             # Start oobabooga server
-            model_dir = "/".join(path.split("/")[:-1])
-            model_name = path.split("/")[-1]
+            model_dir = os.path.dirname(path)
+            model_name = os.path.basename(path)
 
             # Find an open port
             while True:
                 self.port = random.randint(2000, 10000)
-                open_ports = get_open_ports(2000, 10000)
+                open_ports = asyncio.run(get_open_ports(2000, 10000))
                 if self.port not in open_ports:
                     break
 
             # Also find an open port for blocking -- it will error otherwise
             while True:
                 unused_blocking_port = random.randint(2000, 10000)
-                open_ports = get_open_ports(2000, 10000)
+                open_ports = asyncio.run(get_open_ports(2000, 10000))
                 if unused_blocking_port not in open_ports:
                     break
 
@@ -92,7 +92,7 @@ class llm:
             # Wait for it to be ready by checking the port
             num_attempts = 50
             for attempt in range(num_attempts):
-                open_ports = get_open_ports(2000, 10000)
+                open_ports = asyncio.run(get_open_ports(2000, 10000))
                 if self.port in open_ports:
                     if self.verbose:
                         print("Server is ready.")

--- a/ooba/utils/check_port.py
+++ b/ooba/utils/check_port.py
@@ -1,0 +1,11 @@
+import websockets
+
+async def check_port(port, uri='ws://localhost', verbose=False):
+    uri = f"{uri}:{port}"
+    try:
+        async with websockets.connect(uri, close_timeout=1):
+            return port
+    except Exception as e:
+        if verbose:
+            print(f"Failed to connect to {uri}: {str(e)}")
+        return None

--- a/ooba/utils/get_open_ports.py
+++ b/ooba/utils/get_open_ports.py
@@ -1,6 +1,8 @@
 import asyncio
 import websockets
 
+"""Not needed anymore?"""
+
 async def check_websocket(port, uri='ws://localhost'):
     uri = f"{uri}:{port}"
     try:

--- a/ooba/utils/get_open_ports.py
+++ b/ooba/utils/get_open_ports.py
@@ -1,11 +1,27 @@
-import socket
+import asyncio
+import websockets
 
-def get_open_ports(start_port=2000, end_port=10000, host='localhost'):
-    open_ports = []
-    for port in range(start_port, end_port+1):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            socket.setdefaulttimeout(1)
-            result = s.connect_ex((host, port))  # returns 0 if the connection was successful
-            if result == 0:
-                open_ports.append(port)
-    return open_ports
+async def check_websocket(port, uri='ws://localhost'):
+    uri = f"{uri}:{port}"
+    try:
+        async with websockets.connect(uri, close_timeout=1):
+            return port
+    except Exception as e:
+        #print(f"Failed to connect to {uri}: {str(e)}")
+        return None
+
+async def get_open_ports(start_port=2000, end_port=10000, host='localhost', timeout=1.0):
+    tasks = [
+        check_websocket(port, f"ws://{host}") for port in range(start_port, end_port + 1)
+    ]
+    open_ports = await asyncio.gather(*tasks)
+    return [port for port in open_ports if port is not None]
+
+# Example usage
+async def main():
+    open_ports = await get_open_ports(2000, 2020)
+    print(f"Open WebSocket ports: {open_ports}")
+
+# To run the example
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
path's on windows doesn't contain "/" but "\". I used os.path.dirname/basename to get folder path and file path.

Replaced the entire get_open_ports.py so it finds the open ports... Also made it async, because I don't want to wait for a few days for it to finish... I don't think it is nessesary to search all the ports, will make a seperate fix for that. I just pyt the file into gpt4 and made it async