### PR TITLE
Fixes restart every second message

### DIFF
--- a/ooba/install.py
+++ b/ooba/install.py
@@ -138,7 +138,7 @@ def install(force_reinstall=False, verbose=False, cpu=False, gpu_choice=None, fu
     total_lines = 1738
     pbar = tqdm(total=total_lines, ncols=100)
 
-    for cmd in [base_cmd, update_cmd]:
+    for cmd in update_cmd:
         process = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, bufsize=1)
 
         # Read the output line by line

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -42,8 +42,8 @@ class llm:
             install_oobabooga(gpu_choice=self.gpu_choice)
 
             # Start oobabooga server
-            model_dir = "/".join(path.split("/")[:-1])
-            model_name = path.split("/")[-1]
+            model_dir = os.path.dirname(path)
+            model_name = os.path.basename(path)
 
             # Find an open port
             while True:

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -23,8 +23,7 @@ REPO_DIR = os.path.join(get_app_dir(), 'text-generation-ui')
 class llm:
     def __init__(self, path, cpu=False, verbose=False):
 
-        if first_time:
-            print("\nGetting started...")
+        print("Initializing server, please wait...")
 
         try:
             self.path = path
@@ -100,7 +99,7 @@ class llm:
                 else:
                     if self.verbose:
                         print(f"Server is not ready... ({attempt+1}/{num_attempts})")
-                    time.sleep(1.5)
+                    time.sleep(5)
             else:
                 raise Exception("Server took too long to start")
 

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -21,7 +21,7 @@ from .utils.get_app_dir import get_app_dir
 REPO_DIR = os.path.join(get_app_dir(), 'text-generation-ui')
 
 class llm:
-    def __init__(self, path, cpu=False, verbose=False, first_time=True):
+    def __init__(self, path, cpu=False, verbose=False):
 
         if first_time:
             print("\nGetting started...")
@@ -129,20 +129,15 @@ class llm:
                 install_oobabooga(force_reinstall=True, cpu=True)
                 self.__init__(path, cpu=True, verbose=self.verbose)
 
-        if first_time:
-            # Hack to fix it not working multiple times in a row. Must change this soon
-            self.first_time = True
-
-
     def chat(self, messages, max_tokens=None, temperature=0):
 
-        # Hack to fix it not working multiple times in a row. Must change this soon
-        if self.first_time:
-            self.first_time = False
-        #else:
-        #    self.process.terminate()
-        #    self.__init__(self.path, cpu=self.cpu, verbose=self.verbose, first_time=False)
-                
+        # If port is closed, Terminate and restart server
+        if self.port not in get_open_ports(self.port, self.port +1):
+            if self.verbose:
+                print(f"Port {self.port} is not open. Restarting server")
+            self.process.terminate()
+            self.__init__(self.path, cpu=self.cpu, verbose=self.verbose)
+         
         if any([message["role"] == "system" for message in messages[1:]]):
             raise ValueError("Only the first message can have {'role': 'system'}.")
         

--- a/ooba/llm.py
+++ b/ooba/llm.py
@@ -139,9 +139,9 @@ class llm:
         # Hack to fix it not working multiple times in a row. Must change this soon
         if self.first_time:
             self.first_time = False
-        else:
-            self.process.terminate()
-            self.__init__(self.path, cpu=self.cpu, verbose=self.verbose, first_time=False)
+        #else:
+        #    self.process.terminate()
+        #    self.__init__(self.path, cpu=self.cpu, verbose=self.verbose, first_time=False)
                 
         if any([message["role"] == "system" for message in messages[1:]]):
             raise ValueError("Only the first message can have {'role': 'system'}.")


### PR DESCRIPTION
This hack makes Ooba restart every second prompt. I removed the else statement to stop it from restarting all the time. 

If this is supposed to ensure the model is running it's better to check if the port is open and restart it if it is closed.